### PR TITLE
Port chef, apt, and ruby scripts to puppet.

### DIFF
--- a/packer/openjdk-development/openjdk-development.json
+++ b/packer/openjdk-development/openjdk-development.json
@@ -1,14 +1,20 @@
 {
   "provisioners": [
     {
+      "type": "puppet-masterless",
+      "manifest_file": "puppet/manifests/site.pp",
+      "module_paths":  ["puppet/modules"],
+      "facter" : {
+        "fqdn" : "packer-virtualbox-iso"
+      },
+      "execute_command": "echo 'vagrant' | sudo -S -E puppet apply --verbose --modulepath='{{.ModulePath}}' {{.ManifestFile}}"
+    },
+    {
       "type": "shell",
       "scripts": [
         "scripts/build_time.sh",
-        "scripts/apt.sh",
         "scripts/sudo.sh",
         "scripts/vagrant.sh",
-        "scripts/ruby.sh",
-        "scripts/chef.sh",
         "scripts/vbox.sh",
         "scripts/cleanup.sh"
       ],

--- a/packer/openjdk-development/puppet/manifests/site.pp
+++ b/packer/openjdk-development/puppet/manifests/site.pp
@@ -1,0 +1,5 @@
+node 'packer-virtualbox-iso' {
+  include openjdk::packages
+  include openjdk::ruby
+  include openjdk::chef
+}

--- a/packer/openjdk-development/puppet/modules/openjdk/manifests/chef.pp
+++ b/packer/openjdk-development/puppet/modules/openjdk/manifests/chef.pp
@@ -1,0 +1,7 @@
+class openjdk::chef {
+  package { 'chef':
+    provider        => gem,
+    require         => Class['openjdk::ruby'],
+    install_options => [ '--no-ri', '--no-doc' ]
+  }
+}

--- a/packer/openjdk-development/puppet/modules/openjdk/manifests/packages.pp
+++ b/packer/openjdk-development/puppet/modules/openjdk/manifests/packages.pp
@@ -1,0 +1,23 @@
+class openjdk::packages {
+  include openjdk::packages::update
+
+  $packages = [
+    "linux-headers-${::kernelrelease}",
+    'build-essential',
+    'zlib1g-dev',
+    'libssl-dev',
+    'libreadline-gplv2-dev',
+    'libyaml-dev',
+    'vim',
+    'dkms',
+    'nfs-common'
+  ]
+
+  package { $packages: ensure => latest }
+}
+
+class openjdk::packages::update {
+  exec { 'update and upgrade':
+    command => '/usr/bin/apt-get -y update && /usr/bin/apt-get -y upgrade'
+  }
+}

--- a/packer/openjdk-development/puppet/modules/openjdk/manifests/ruby.pp
+++ b/packer/openjdk-development/puppet/modules/openjdk/manifests/ruby.pp
@@ -1,0 +1,11 @@
+class openjdk::ruby {
+
+  $ruby = 'ruby2.0'
+
+  package { [ $ruby, "${ruby}-dev", 'ruby-switch' ]: ensure => latest }
+
+  exec { 'update-ruby-version':
+    command => "/usr/bin/ruby-switch --set ${ruby}",
+    require => Package[$ruby]
+  }
+}


### PR DESCRIPTION
This marks the start of porting the shell scripts to puppet. apt.sh was an easy candidate, and not building ruby from scratch saves several minutes of build time. 
