### PR TITLE
Added UI (X incl. xfce) and Eclipse installation

### DIFF
--- a/packer/openjdk-development/openjdk-development.json
+++ b/packer/openjdk-development/openjdk-development.json
@@ -1,13 +1,23 @@
 {
   "provisioners": [
     {
+      "type": "shell",
+      "only": ["virtualbox-iso"],
+      "inline": [
+        "echo 'vagrant' | sudo -S  chmod 666 /etc/hosts",
+        "echo '127.0.0.1  packer-virtualbox-iso.localdomain packer-virtualbox-iso localhost' | cat > /etc/hosts",
+        "echo 'vagrant' | sudo -S  chmod 644 /etc/hosts",
+        "echo 'vagrant' | sudo -S hostnamectl --static --transient set-hostname packer-virtualbox-iso.localdomain"
+      ]
+    },
+    {
       "type": "puppet-masterless",
       "manifest_file": "puppet/manifests/site.pp",
       "module_paths":  ["puppet/modules"],
       "facter" : {
         "fqdn" : "packer-virtualbox-iso"
       },
-      "execute_command": "echo 'vagrant' | sudo -S -E puppet apply --verbose --modulepath='{{.ModulePath}}' {{.ManifestFile}}"
+      "execute_command": "echo 'vagrant' | sudo -S -E puppet module install --modulepath='{{.ModulePath}}' smarchive-archive; echo 'vagrant' | sudo -S -E puppet apply --verbose --modulepath='{{.ModulePath}}' {{.ManifestFile}}"
     },
     {
       "type": "shell",
@@ -51,7 +61,8 @@
       "guest_additions_path": "VBoxGuestAdditions_{{.Version}}.iso",
       "virtualbox_version_file": ".vbox_version",
       "vboxmanage": [
-        [ "modifyvm", "{{.Name}}", "--memory", "512" ],
+        [ "modifyvm", "{{.Name}}", "--memory", "2048" ],
+        [ "modifyvm", "{{.Name}}", "--vram", "32" ],
         [ "modifyvm", "{{.Name}}", "--cpus",   "1"   ]
       ]
     }

--- a/packer/openjdk-development/openjdk-development.json
+++ b/packer/openjdk-development/openjdk-development.json
@@ -1,16 +1,6 @@
 {
   "provisioners": [
     {
-      "type": "shell",
-      "only": ["virtualbox-iso"],
-      "inline": [
-        "echo 'vagrant' | sudo -S  chmod 666 /etc/hosts",
-        "echo '127.0.0.1  packer-virtualbox-iso.localdomain packer-virtualbox-iso localhost' | cat > /etc/hosts",
-        "echo 'vagrant' | sudo -S  chmod 644 /etc/hosts",
-        "echo 'vagrant' | sudo -S hostnamectl --static --transient set-hostname packer-virtualbox-iso.localdomain"
-      ]
-    },
-    {
       "type": "puppet-masterless",
       "manifest_file": "puppet/manifests/site.pp",
       "module_paths":  ["puppet/modules"],

--- a/packer/openjdk-development/puppet/manifests/site.pp
+++ b/packer/openjdk-development/puppet/manifests/site.pp
@@ -4,4 +4,5 @@ node 'packer-virtualbox-iso' {
   include openjdk::chef
   include openjdk::vagrant
   include openjdk::sudo
+  include openjdk::eclipse
 }

--- a/packer/openjdk-development/puppet/modules/openjdk/manifests/eclipse.pp
+++ b/packer/openjdk-development/puppet/modules/openjdk/manifests/eclipse.pp
@@ -5,7 +5,7 @@
 # == Parameters:
 #
 # == Actions:
-#   Install Eclipse Juno
+#   Install Eclipse Kepler
 #
 # == Requires:
 #   - Module['Archive']

--- a/packer/openjdk-development/puppet/modules/openjdk/manifests/eclipse.pp
+++ b/packer/openjdk-development/puppet/modules/openjdk/manifests/eclipse.pp
@@ -1,0 +1,31 @@
+# = Class: eclipse
+#
+# Manage Eclipse through Puppet
+#
+# == Parameters:
+#
+# == Actions:
+#   Install Eclipse Juno
+#
+# == Requires:
+#   - Module['Archive']
+class openjdk::eclipse {
+    $release = "eclipse-jee-kepler-SR1-linux-gtk-x86_64"
+    $baseUrl = "http://ftp.osuosl.org/pub/eclipse/technology/epp/downloads/release/kepler/SR1/"
+
+    archive { $release:
+    ensure     => present,
+    timeout    => 7200,
+    url        => "${baseUrl}${release}.tar.gz",
+    checksum   => false,
+    src_target => '/usr/src',
+    target     => '/opt',
+    extension  => 'tar.gz',
+  }
+
+  file { "/opt/eclipse":
+    ensure  => link,
+    target  => "/opt/${release}",
+    require => Archive[$release],
+  }
+}

--- a/packer/openjdk-development/puppet/modules/openjdk/manifests/packages.pp
+++ b/packer/openjdk-development/puppet/modules/openjdk/manifests/packages.pp
@@ -24,6 +24,10 @@ class openjdk::packages {
     'vim',
     'zip',
     'zlib1g-dev',
+    'xorg',
+    'xdm',
+    'xfce4',
+    'xfce4-goodies'
   ]
 
   package { $packages: ensure => latest }


### PR DESCRIPTION
Hi,

here's a suggestion to add GUI and Eclipse installation to the VM build.
just started last week to work hands-on with packer, puppet etc. - so please forgive me if things are not as elaborate as they could be.
## Changes in this set:

Added GUI - X incl. xfce - and Eclipse installation (site.pp,
packages.pp, new eclipse.pp)
Packer JSON file modified:
- a workaround to set the hostname correctly (did not work on my
  machine at least / OS X 10.9.1, virtual box 4.3.6; it stayed at
  „localhost“, making the build fail as the node name could not be
  matched afterwards)
- an addition to the puppet execute_command (install archive module)
## \- increasing RAM and (for GUI) VRAM for

Discussion:
Not sure whether the hostname workaround should be pulled actually. Martijn already confirmed it works on his machine, and he is on OS X Maverick as well.
An alternative to the manual installation of the archive module could be to use librarian_puppet I had looked into it and thought it was overkill however (maybe that changes as we add more stuff)
There seems to be a ready module to install IntelliJ IDEA (smarchive/idea), but I assume that Eclipse is more widespread, so I started with it. 

Cheers,
Andreas
